### PR TITLE
Add PDFiumViewer

### DIFF
--- a/args/windows.args.gn
+++ b/args/windows.args.gn
@@ -15,3 +15,4 @@ pdf_enable_xfa = false
 
 # Generate a 32-bit version
 target_cpu = "x86"
+is_debug = false

--- a/args/windows.args.gn
+++ b/args/windows.args.gn
@@ -11,7 +11,7 @@ pdf_enable_v8 = false
 pdf_enable_xfa = false
 
 # Enable experimental win32 GDI APIs.
-pdf_use_win32_gdi = true
+#pdf_use_win32_gdi = true
 
 # Generate a 32-bit version
 target_cpu = "x86"

--- a/args/windows.args.gn
+++ b/args/windows.args.gn
@@ -12,3 +12,6 @@ pdf_enable_xfa = false
 
 # Enable experimental win32 GDI APIs.
 pdf_use_win32_gdi = true
+
+# Generate a 32-bit version
+target_cpu = "x86"

--- a/build.bat
+++ b/build.bat
@@ -60,10 +60,11 @@ call %DepotTools_DIR%\python.bat -m pip install pywin32 || exit /b
 : Patch
 cd %PDFium_SOURCE_DIR%
 copy "%PDFium_PATCH_DIR%\resources.rc" . || exit /b
-git.exe apply -v "%PDFium_PATCH_DIR%\shared_library.patch" || exit /b
-git.exe apply -v "%PDFium_PATCH_DIR%\relative_includes.patch" || exit /b
-if "%PDFium_V8%"=="enabled" git.exe apply -v "%PDFium_PATCH_DIR%\v8_init.patch" || exit /b
-git.exe -C build apply -v "%PDFium_PATCH_DIR%\rc_compiler.patch" || exit /b
+git.exe apply --ignore-space-change --ignore-whitespace -v "%PDFium_PATCH_DIR%\shared_library.patch" || exit /b
+git.exe apply --ignore-space-change --ignore-whitespace -v "%PDFium_PATCH_DIR%\relative_includes.patch" || exit /b
+if "%PDFium_V8%"=="enabled" git.exe apply --ignore-space-change --ignore-whitespace -v "%PDFium_PATCH_DIR%\v8_init.patch" || exit /b
+git.exe -C build apply --ignore-space-change --ignore-whitespace -v "%PDFium_PATCH_DIR%\rc_compiler.patch" || exit /b
+git.exe apply --ignore-space-change --ignore-whitespace -v "%PDFium_PATCH_DIR%\pdfiumviewer.patch" || exit /b
 
 : Configure
 copy %PDFium_ARGS% %PDFium_BUILD_DIR%\args.gn

--- a/patches/pdfiumviewer.patch
+++ b/patches/pdfiumviewer.patch
@@ -1,0 +1,138 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 72fcb2a81..7da9dc4bf 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -17,10 +17,11 @@ group("freetype_common") {
+ config("pdfium_common_config") {
+   cflags = []
+   ldflags = []
+-  include_dirs = [ "." ]
++  include_dirs = [ ".", "v8/include" ]
+   defines = [
+     "PNG_PREFIX",
+     "PNG_USE_READ_MACROS",
++    "FPDFSDK_EXPORTS"
+   ]
+ 
+   if (!use_system_libopenjpeg2) {
+diff --git a/fpdfsdk/BUILD.gn b/fpdfsdk/BUILD.gn
+index 20a925a72..33db605a8 100644
+--- a/fpdfsdk/BUILD.gn
++++ b/fpdfsdk/BUILD.gn
+@@ -70,6 +70,7 @@ source_set("fpdfsdk") {
+     "fpdf_transformpage.cpp",
+     "fpdf_view.cpp",
+     "ipdfsdk_annothandler.h",
++    "pdfiumviewer.cpp"
+   ]
+ 
+   configs += [ "../:pdfium_core_config" ]
+diff --git a/fpdfsdk/pdfiumviewer.cpp b/fpdfsdk/pdfiumviewer.cpp
+new file mode 100644
+index 000000000..3e7c4cebf
+--- /dev/null
++++ b/fpdfsdk/pdfiumviewer.cpp
+@@ -0,0 +1,102 @@
++// Copyright (c) 2015 Pieter van Ginkel. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "public/fpdfview.h"
++#if PDF_ENABLE_V8
++#include "v8/include/v8.h"
++#include "v8/include/libplatform/libplatform.h"
++#endif // PDF_ENABLE_V8
++
++extern "C"
++{
++	FPDF_EXPORT void FPDF_CALLCONV FPDF_AddRef();
++	FPDF_EXPORT void FPDF_CALLCONV FPDF_Release();
++}
++
++class RefCounter
++{
++private:
++	CRITICAL_SECTION cs;
++	int refCount;
++#if PDF_ENABLE_V8
++	v8::Platform* platform;
++#endif // PDF_ENABLE_V8
++
++public:
++	RefCounter()
++	{
++		::InitializeCriticalSection(&cs);
++		refCount = 0;
++#if PDF_ENABLE_V8
++		platform = NULL;
++#endif // PDF_ENABLE_V8
++	}
++
++	~RefCounter()
++	{
++		::DeleteCriticalSection(&cs);
++	}
++
++	void Enter()
++	{
++		::EnterCriticalSection(&cs);
++	}
++
++	void Leave()
++	{
++		::LeaveCriticalSection(&cs);
++	}
++
++	void AddRef()
++	{
++		::EnterCriticalSection(&cs);
++
++		if (refCount == 0)
++		{
++#if PDF_ENABLE_V8
++			v8::V8::InitializeICU();
++			platform = v8::platform::CreateDefaultPlatform();
++			v8::V8::InitializePlatform(platform);
++			v8::V8::Initialize();
++#endif // PDF_ENABLE_V8
++
++			FPDF_InitLibrary();
++		}
++
++		refCount++;
++
++		::LeaveCriticalSection(&cs);
++	}
++
++	void Release()
++	{
++		::EnterCriticalSection(&cs);
++
++		refCount--;
++
++		if (refCount == 0)
++		{
++			FPDF_DestroyLibrary();
++#if PDF_ENABLE_V8
++			v8::V8::ShutdownPlatform();
++			delete platform;
++#endif // PDF_ENABLE_V8
++		}
++
++		::LeaveCriticalSection(&cs);
++	}
++};
++
++static RefCounter refCounter;
++
++
++FPDF_EXPORT void FPDF_CALLCONV FPDF_AddRef()
++{
++	refCounter.AddRef();
++}
++
++FPDF_EXPORT void FPDF_CALLCONV FPDF_Release()
++{
++	refCounter.Release();
++}
+\ No newline at end of file


### PR DESCRIPTION
* Added the modifications outlined [here](https://github.com/pvginkel/PdfiumViewer/wiki/Building-PDFium) as another `.patch` file to be applied like the others. This should allow us to build the `pdfium.dll` without any manual intervention beyond the standard setup for building with `ninja` and `gclient`. The patch primarily just adds the `pdfiumviewer.cpp` file so that the PDFiumViewer hooks will be included in the `.dll`.
* Added `--ignore-space-change --ignore-whitespace` to the `git apply` command so that it would ignore whitespace differences when applying the patches. They were failing without those switches.
* Not using the experimental GDI drawing available for Windows builds
* Targeting `x86` because that's what we target elsewhere